### PR TITLE
Add frontend main page

### DIFF
--- a/frontend_xd/src/App.jsx
+++ b/frontend_xd/src/App.jsx
@@ -1,18 +1,18 @@
-import { useState } from 'react'
-import './App.css'
-import { Routes, Route } from 'react-router-dom'
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Login from './Login.jsx';
+import MainPage from './MainPage.jsx';
+import './App.css';
 
 function App() {
-
   return (
-    <>
+    <Router>
       <Routes>
         <Route path="/" element={<Login />} />
-        <Route path="/admin" element={<Admin />} />
-        <Route path="/user" element={<User />} />
+        <Route path="/main" element={<MainPage />} />
       </Routes>
-    </>
-  )
+    </Router>
+  );
 }
 
-export default App
+export default App;

--- a/frontend_xd/src/MainPage.css
+++ b/frontend_xd/src/MainPage.css
@@ -1,0 +1,30 @@
+.main-container {
+  font-family: Arial, Helvetica, sans-serif;
+  padding: 2rem;
+  color: #fff;
+}
+
+.cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+}
+
+.card {
+  background: #222;
+  border: 1px solid #555;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.card img {
+  max-width: 100%;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.error {
+  color: red;
+}

--- a/frontend_xd/src/MainPage.jsx
+++ b/frontend_xd/src/MainPage.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import './MainPage.css';
+
+function MainPage() {
+  const [activities, setActivities] = useState([]);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    axios.get('http://localhost:8000/actividades')
+      .then((response) => {
+        setActivities(response.data);
+        setError(null);
+      })
+      .catch(() => {
+        setError('No se pudieron cargar las actividades');
+      });
+  }, []);
+
+  return (
+    <div className="main-container">
+      <h1>Actividades</h1>
+      {error && <p className="error">{error}</p>}
+      <div className="cards">
+        {activities.map((act) => (
+          <div key={act.id} className="card">
+            <img src={act.imagen} alt={act.titulo} />
+            <h2>{act.titulo}</h2>
+            <p>{act.descripcion}</p>
+            <p>
+              <strong>Dia:</strong> {act.dia} - <strong>Horario:</strong> {act.horario}
+            </p>
+            <p>
+              <strong>Cupo:</strong> {act.cupo}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default MainPage;

--- a/frontend_xd/src/main.jsx
+++ b/frontend_xd/src/main.jsx
@@ -1,9 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import Login from './Login.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.jsx';
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <Login />
+    <App />
   </StrictMode>,
-)
+);


### PR DESCRIPTION
## Summary
- implement `MainPage` React component to fetch and display activities
- wire `MainPage` and `Login` using React Router
- update entry point to render new `App`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68410b697f388327b024508d8fcf1948