### PR TITLE
Add activity detail endpoint

### DIFF
--- a/backend_xd/app/routes.go
+++ b/backend_xd/app/routes.go
@@ -10,7 +10,7 @@ func MapRoutes() {
 	// Rutas públicas
 	Router.POST("/login", handlers.LoginHandler)
 	Router.GET("/actividades", activities.GetAllActivities)
-	// Router.GET("/actividad/:id", handlers.ObtenerActividad)
+	Router.GET("/actividad/:id", activities.GetActivityByID)
 
 	// // Rutas de inscripción (se asume usuario logueado, pero sin middleware por ahora)
 	// Router.POST("/inscribirse/:id", handlers.InscribirseActividad)

--- a/backend_xd/handlers/activities/get_activity_by_id.go
+++ b/backend_xd/handlers/activities/get_activity_by_id.go
@@ -1,0 +1,27 @@
+package activities
+
+import (
+	"net/http"
+	"strconv"
+
+	"proyecto2025/backend/repositories"
+
+	"github.com/gin-gonic/gin"
+)
+
+func GetActivityByID(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ID inválido"})
+		return
+	}
+
+	actividad, err := repositories.GetActividadByID(id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Actividad no encontrada"})
+		return
+	}
+
+	c.JSON(http.StatusOK, actividad)
+}

--- a/backend_xd/repositories/get_activity_by_id.go
+++ b/backend_xd/repositories/get_activity_by_id.go
@@ -1,0 +1,24 @@
+package repositories
+
+import (
+	"proyecto2025/backend/database"
+	"proyecto2025/backend/dto"
+	"proyecto2025/backend/models"
+)
+
+func GetActividadByID(id int) (*dto.ActividadDTO, error) {
+	var actividad models.Activity
+	if err := database.DB.First(&actividad, id).Error; err != nil {
+		return nil, err
+	}
+	result := &dto.ActividadDTO{
+		ID:          uint(actividad.Id),
+		Titulo:      actividad.Titulo,
+		Dia:         actividad.Dia,
+		Horario:     actividad.Horario,
+		Imagen:      actividad.Imagen,
+		Cupo:        actividad.Cupo,
+		Descripcion: actividad.Descripcion,
+	}
+	return result, nil
+}

--- a/frontend_xd/src/App.jsx
+++ b/frontend_xd/src/App.jsx
@@ -1,18 +1,18 @@
-import { useState } from 'react'
-import './App.css'
-import { Routes, Route } from 'react-router-dom'
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Login from './Login.jsx';
+import MainPage from './MainPage.jsx';
+import './App.css';
 
 function App() {
-
   return (
-    <>
+    <Router>
       <Routes>
         <Route path="/" element={<Login />} />
-        <Route path="/admin" element={<Admin />} />
-        <Route path="/user" element={<User />} />
+        <Route path="/main" element={<MainPage />} />
       </Routes>
-    </>
-  )
+    </Router>
+  );
 }
 
-export default App
+export default App;

--- a/frontend_xd/src/Login.jsx
+++ b/frontend_xd/src/Login.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from "react";
 import axios from "axios";
+import { useNavigate } from "react-router-dom";
 import "./Login.css";
 
 const Login = () => {
   const [user, setUser] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState(null);
+  const navigate = useNavigate();
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -22,8 +24,7 @@ const Login = () => {
       // Guardar token en localStorage
       localStorage.setItem("token", response.data.token);
 
-      // (Opcional) Redirigir a otra página después del login
-      // window.location.href = "/home"; // o usá navigate si tenés react-router
+      navigate('/main');
     } catch (error) {
       console.error("Error al hacer login:", error);
       if (error.response && error.response.status === 401) {

--- a/frontend_xd/src/MainPage.css
+++ b/frontend_xd/src/MainPage.css
@@ -1,0 +1,37 @@
+.main-container {
+  font-family: Arial, Helvetica, sans-serif;
+  padding: 2rem;
+  color: #fff;
+}
+
+.cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+}
+
+.card {
+  background: #222;
+  border: 1px solid #555;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.card img {
+  max-width: 100%;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.error {
+  color: red;
+}
+
+.detail {
+  margin-top: 2rem;
+  background: #333;
+  padding: 1rem;
+  border-radius: 8px;
+}

--- a/frontend_xd/src/MainPage.jsx
+++ b/frontend_xd/src/MainPage.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import './MainPage.css';
+
+function MainPage() {
+  const [activities, setActivities] = useState([]);
+  const [error, setError] = useState(null);
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    axios.get('http://localhost:8000/actividades')
+      .then((response) => {
+        setActivities(response.data);
+        setError(null);
+      })
+      .catch(() => {
+        setError('No se pudieron cargar las actividades');
+      });
+  }, []);
+
+  const fetchActivity = (id) => {
+    axios.get(`http://localhost:8000/actividad/${id}`)
+      .then((response) => {
+        setSelected(response.data);
+        setError(null);
+      })
+      .catch(() => {
+        setError('No se pudo obtener la actividad');
+      });
+  };
+
+  return (
+    <div className="main-container">
+      <h1>Actividades</h1>
+      {error && <p className="error">{error}</p>}
+      <div className="cards">
+        {activities.map((act) => (
+          <div key={act.id} className="card">
+            <img src={act.imagen} alt={act.titulo} />
+            <h2>{act.titulo}</h2>
+            <p>{act.descripcion}</p>
+            <p>
+              <strong>Dia:</strong> {act.dia} - <strong>Horario:</strong> {act.horario}
+            </p>
+            <p>
+              <strong>Cupo:</strong> {act.cupo}
+            </p>
+            <button type="button" onClick={() => fetchActivity(act.id)}>
+              Ver detalles
+            </button>
+          </div>
+        ))}
+      </div>
+      {selected && (
+        <div className="detail">
+          <h2>Detalle de actividad</h2>
+          <p>
+            <strong>Título:</strong> {selected.titulo}
+          </p>
+          <p>{selected.descripcion}</p>
+          <p>
+            <strong>Día:</strong> {selected.dia} - <strong>Horario:</strong>{' '}
+            {selected.horario}
+          </p>
+          <p>
+            <strong>Cupo:</strong> {selected.cupo}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MainPage;

--- a/frontend_xd/src/main.jsx
+++ b/frontend_xd/src/main.jsx
@@ -1,9 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import Login from './Login.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.jsx';
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <Login />
+    <App />
   </StrictMode>,
-)
+);


### PR DESCRIPTION
## Summary
- implement `GetActivityByID` handler and repository method
- expose new `/actividad/:id` route
- show activity detail in the front-end `MainPage`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68410b697f388327b024508d8fcf1948